### PR TITLE
Add Jupyter Notebook as first-class content type

### DIFF
--- a/cli/tutors-gen-lib/src/services/course-builder.ts
+++ b/cli/tutors-gen-lib/src/services/course-builder.ts
@@ -21,7 +21,7 @@ import {
   readVideoIds,
   removeLeadingHashes,
 } from "../utils/lr-utils.ts";
-import { type Archive, type Composite, type Course, isCompositeLo, type Lab, type Lo, Podcast, preOrder, type Talk, Tutorial } from "@tutors/tutors-model-lib";
+import { type Archive, type Composite, type Course, isCompositeLo, type Lab, type Lo, type Notebook, type NotebookCell, type NotebookOutput, Podcast, preOrder, type Talk, Tutorial } from "@tutors/tutors-model-lib";
 import { readWholeFile, readYamlFile } from "../utils/file-utils.ts";
 import type { LearningResource } from "../types/types.ts";
 
@@ -103,10 +103,67 @@ function buildLab(lo: Lo, lr: LearningResource): Lo {
   return lo;
 }
 
+function buildNotebook(lo: Lo, lr: LearningResource) {
+  const notebook = lo as Notebook;
+  const ipynbFiles = getFilesWithType(lr, "ipynb");
+  if (ipynbFiles.length === 0) return;
+
+  const ipynbContent = readWholeFile(ipynbFiles[0]);
+  const nb = JSON.parse(ipynbContent);
+
+  notebook.kernelLanguage = nb.metadata?.kernelspec?.language || nb.metadata?.language_info?.name || "python";
+  notebook.kernelName = nb.metadata?.kernelspec?.display_name || notebook.kernelLanguage;
+
+  notebook.cells = (nb.cells || []).map((cell: any, index: number): NotebookCell => {
+    const source = Array.isArray(cell.source) ? cell.source.join("") : (cell.source || "");
+    const outputs: NotebookOutput[] = (cell.outputs || []).map((output: any): NotebookOutput => {
+      const result: NotebookOutput = {
+        outputType: output.output_type as NotebookOutput["outputType"],
+      };
+      if (output.name) result.name = output.name;
+      if (output.execution_count != null) result.executionCount = output.execution_count;
+      if (output.text) {
+        result.text = Array.isArray(output.text) ? output.text.join("") : output.text;
+      }
+      if (output.traceback) {
+        result.traceback = output.traceback;
+      }
+      if (output.data) {
+        const data: Record<string, string> = {};
+        for (const [mime, content] of Object.entries(output.data)) {
+          const value = Array.isArray(content) ? (content as string[]).join("") : (content as string);
+          data[mime] = value;
+        }
+        result.data = data;
+      }
+      return result;
+    });
+
+    return {
+      cellType: cell.cell_type as NotebookCell["cellType"],
+      source,
+      outputs,
+      executionCount: cell.execution_count ?? null,
+      metadata: cell.metadata || {},
+      id: cell.id || `cell-${index}`,
+    };
+  });
+
+  notebook.img = getLabImage(lr);
+  notebook.imgFile = `img/${getLabImageFile(lr)}`;
+  if (!notebook.img) {
+    notebook.img = getImage(lr);
+    notebook.imgFile = getImageFile(lr);
+  }
+}
+
 function buildSimpleLo(lo: Lo, lr: LearningResource): Lo {
   switch (lo.type) {
     case "lab":
       buildLab(lo, lr);
+      break;
+    case "notebook":
+      buildNotebook(lo, lr);
       break;
     case "talk":
       buildTalk(lo, lr);

--- a/cli/tutors-gen-lib/src/utils/file-utils.ts
+++ b/cli/tutors-gen-lib/src/utils/file-utils.ts
@@ -46,9 +46,10 @@ export function findLastMatchingString(
 ): string {
   path = path.replace(courseRoot, "");
   const segments = path.split("/");
+  const sortedTypes = [...loTypes].sort((a, b) => b.length - a.length);
   for (let i = segments.length - 1; i >= 0; i--) {
-    for (let j = 0; j < loTypes.length; j++) {
-      const loType = loTypes[j].slice(1);
+    for (let j = 0; j < sortedTypes.length; j++) {
+      const loType = sortedTypes[j].slice(1);
       if (segments[i].startsWith(loType)) {
         return loType;
       }

--- a/cli/tutors-model-lib/src/types/learning-objects.ts
+++ b/cli/tutors-model-lib/src/types/learning-objects.ts
@@ -117,6 +117,43 @@ export type Note = Lo & {
 };
 
 /**
+ * Notebook output from a code cell execution
+ */
+export type NotebookOutput = {
+  outputType: "stream" | "execute_result" | "display_data" | "error";
+  text?: string;
+  data?: Record<string, string>;
+  traceback?: string[];
+  name?: string;
+  executionCount?: number | null;
+};
+
+/**
+ * A single cell in a Jupyter notebook
+ */
+export type NotebookCell = {
+  cellType: "markdown" | "code" | "raw";
+  source: string;
+  sourceHtml?: string;
+  outputs: NotebookOutput[];
+  outputsHtml?: string;
+  executionCount: number | null;
+  metadata: Record<string, unknown>;
+  id: string;
+};
+
+/**
+ * Notebook learning object
+ * Represents a Jupyter notebook with cells
+ */
+export type Notebook = Lo & {
+  type: "notebook";
+  cells: NotebookCell[];
+  kernelLanguage: string;
+  kernelName: string;
+};
+
+/**
  * Podcast learning object
  * Represents a podcast episode
  */

--- a/cli/tutors-model-lib/src/types/type-utils.ts
+++ b/cli/tutors-model-lib/src/types/type-utils.ts
@@ -28,6 +28,7 @@ export const simpleTypes = [
   "book",
   "lab",
   "tutorial",
+  "notebook",
 ];
 
 /**
@@ -77,6 +78,7 @@ export const preOrder: Map<string, number> = new Map([
   ["paneltalk", 13],
   ["panelvideo", 14],
   ["podcast", 15],
+  ["notebook", 16],
 ]);
 
 /**

--- a/cli/tutors-model-lib/src/utils/course-utils.ts
+++ b/cli/tutors-model-lib/src/utils/course-utils.ts
@@ -102,7 +102,7 @@ export function createCompanions(course: Course) {
 export function createWalls(course: Course) {
   course.walls = [];
   course.wallMap = new Map<string, Lo[]>();
-  ["talk", "tutorial", "note", "lab", "podcast", "web", "archive", "github"].forEach((type) => addWall(course, type as LoType));
+  ["talk", "tutorial", "note", "lab", "notebook", "podcast", "web", "archive", "github"].forEach((type) => addWall(course, type as LoType));
   course.wallBar = {
     show: true,
     bar: [],


### PR DESCRIPTION
## Summary

- Add `NotebookOutput`, `NotebookCell`, and `Notebook` types to tutors-model-lib
- Register `notebook` in `simpleTypes` array, `preOrder` map (position 16), and wall types
- Add `buildNotebook()` function to course-builder that parses `.ipynb` files: extracts cells with joined source arrays, structured outputs (stream, execute_result, display_data, error), kernel language/name from notebook metadata
- Fix `findLastMatchingString()` to sort type prefixes longest-first, preventing `notebook-*` folders from matching as `note`

## Files changed

- `cli/tutors-model-lib/src/types/learning-objects.ts` — NotebookOutput, NotebookCell, Notebook types
- `cli/tutors-model-lib/src/types/type-utils.ts` — simpleTypes + preOrder entries
- `cli/tutors-model-lib/src/utils/course-utils.ts` — wall types
- `cli/tutors-gen-lib/src/services/course-builder.ts` — buildNotebook + case in buildSimpleLo
- `cli/tutors-gen-lib/src/utils/file-utils.ts` — longest-prefix-first type matching

## Course folder convention

```
topic-01-example/
  notebook-my-analysis/
    notebook-my-analysis.md    # Card title & summary
    notebook-my-analysis.png   # Card image (optional)
    analysis.ipynb             # The Jupyter notebook
```

## Companion PR

Reader: https://github.com/tutors-sdk/tutors/pull/1064

## Test plan

- [ ] Create a course with a `notebook-*` folder containing a `.ipynb` file
- [ ] Run `deno run --allow-all cli/tutors/main.ts` from the course directory
- [ ] Verify `tutors.json` contains notebook Lo with type "notebook", cells array, kernel metadata
- [ ] Verify all cell types (markdown, code, raw) and output types (stream, execute_result, error, display_data) are correctly extracted
- [ ] Verify a `note-*` folder still correctly resolves as type "note"

🤖 Generated with [Claude Code](https://claude.com/claude-code)