### PR TITLE
Fix pruneTree splice-during-iteration bug

### DIFF
--- a/cli/tutors-gen-lib/src/services/resource-builder.ts
+++ b/cli/tutors-gen-lib/src/services/resource-builder.ts
@@ -47,12 +47,8 @@ export function build(dir: string): LearningResource {
 }
 
 export function pruneTree(lr: LearningResource): void {
-  lr.lrs.forEach((resource, index) => {
-    if (resource.type === "unknown") {
-      lr.lrs.splice(index, 1);
-    }
-    pruneTree(resource);
-  });
+  lr.lrs = lr.lrs.filter((resource) => resource.type !== "unknown");
+  lr.lrs.forEach((resource) => pruneTree(resource));
 }
 
 export function buildTree(dir: string): LearningResource {


### PR DESCRIPTION
## Summary

- Replace `forEach` + `splice` with `filter()` in `pruneTree()` to prevent skipping consecutive unknown elements during tree pruning
- The original code mutated the array while iterating, causing the next element to shift into the current index and be skipped

## Test plan

- [ ] Generate a course with consecutive unknown-type folders and verify both are pruned
- [ ] Run existing course generation and verify output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)