### PR TITLE
Fix Marp talk route and content reading

### DIFF
--- a/cli/tutors-gen-lib/src/services/course-builder.ts
+++ b/cli/tutors-gen-lib/src/services/course-builder.ts
@@ -31,8 +31,14 @@ function buildTalk(lo: Lo, lr: LearningResource) {
   const talk = lo as Talk;
   talk.pdf = getPdf(lr);
   talk.pdfFile = getPdfFile(lr);
-  if (!talk.pdf) {
+  if (!talk.pdf && lo.video) {
     talk.route = lo.video;
+  }
+  const marpFile = getFileWithType(lr, ["marp"]);
+  if (marpFile) {
+    const contents = frontMatter(readWholeFile(marpFile));
+    lo.contentMd = contents.body;
+    lo.frontMatter = { ...lo.frontMatter, ...contents.attributes };
   }
 }
 

--- a/cli/tutors-model-lib/src/types/media-types.ts
+++ b/cli/tutors-model-lib/src/types/media-types.ts
@@ -40,6 +40,7 @@ export const assetTypes: string[] = imageTypes.concat([
   "java",
   "py",
   "js",
+  "marp",
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- **Fix route blanking**: `buildTalk()` was unconditionally overwriting `talk.route` with `lo.video` when no PDF existed. For Marp talks (no PDF, no video), this set the route to empty string, causing the card link to navigate back to the current page instead of opening the talk.
- **Read .marp content**: When a `.marp` file exists in a talk folder, its content and frontmatter are now read into `lo.contentMd` and `lo.frontMatter`. This allows the reader to detect `marp: true` and render the Marp slide viewer.
- **Asset type**: Added `.marp` to `assetTypes` so the file is copied to the generated output.

### Companion PRs
- tutors-sdk/tutors#1063 (reader: Mermaid + Marp slide support)
- tutors-sdk/tutors-reference-course#2 (reference course with Marp talk example)

## Test plan
- [ ] Generate a course with a `talk-*` folder containing only a `.marp` file (no PDF) — verify the talk card links to the correct route
- [ ] Verify the generated JSON includes the `.marp` file's content in `contentMd` and `marp: true` in `frontMatter`
- [ ] Verify existing PDF talks still work (no regression)
- [ ] Verify video talks still route correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)