### PR TITLE
Add testing infrastructure with 91 unit tests and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches: [development]
+  pull_request:
+    branches: [development]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run unit tests
+        working-directory: cli
+        run: deno test --no-check -A
+
+      - name: Run unit tests with coverage
+        working-directory: cli
+        run: deno test --no-check -A --coverage=coverage
+
+      - name: Generate coverage report
+        working-directory: cli
+        run: deno coverage coverage

--- a/cli/tutors-gen-lib/test/file-utils.test.ts
+++ b/cli/tutors-gen-lib/test/file-utils.test.ts
@@ -1,0 +1,105 @@
+import { assertEquals } from "jsr:@std/assert";
+import {
+  removeFirstLine,
+  findFirstMatchingString,
+  findLastMatchingString,
+  getFileName,
+  getFileType,
+  getHeaderFromBody,
+  withoutHeaderFromBody,
+} from "../src/utils/file-utils.ts";
+
+// --- removeFirstLine ---
+
+Deno.test("removeFirstLine removes the first line", () => {
+  assertEquals(removeFirstLine("first\nsecond\nthird"), "second\nthird");
+});
+
+Deno.test("removeFirstLine returns empty for single line", () => {
+  assertEquals(removeFirstLine("only"), "");
+});
+
+Deno.test("removeFirstLine handles empty string", () => {
+  assertEquals(removeFirstLine(""), "");
+});
+
+// --- getFileName ---
+
+Deno.test("getFileName extracts filename from path", () => {
+  assertEquals(getFileName("/home/user/file.txt"), "file.txt");
+});
+
+Deno.test("getFileName extracts filename from windows path", () => {
+  assertEquals(getFileName("C:\\Users\\test\\file.txt"), "file.txt");
+});
+
+Deno.test("getFileName returns filename when no path", () => {
+  assertEquals(getFileName("file.txt"), "file.txt");
+});
+
+// --- getFileType ---
+
+Deno.test("getFileType returns extension", () => {
+  assertEquals(getFileType("file.txt"), "txt");
+});
+
+Deno.test("getFileType returns last extension for multiple dots", () => {
+  assertEquals(getFileType("file.test.ts"), "ts");
+});
+
+Deno.test("getFileType returns empty for no extension", () => {
+  assertEquals(getFileType("Makefile"), "");
+});
+
+// --- getHeaderFromBody ---
+
+Deno.test("getHeaderFromBody extracts markdown header", () => {
+  assertEquals(getHeaderFromBody("# My Title\nSome content"), " My Title");
+});
+
+Deno.test("getHeaderFromBody returns first line when no hash", () => {
+  assertEquals(getHeaderFromBody("Plain Title\nContent here"), "Plain Title");
+});
+
+// --- withoutHeaderFromBody ---
+
+Deno.test("withoutHeaderFromBody returns content after header", () => {
+  const body = "# Title\n\nThis is the summary\nMore content";
+  const result = withoutHeaderFromBody(body);
+  assertEquals(result, "This is the summary");
+});
+
+Deno.test("withoutHeaderFromBody trims whitespace around header", () => {
+  const body = "# Title\n\nSummary line\nMore content";
+  const result = withoutHeaderFromBody(body);
+  assertEquals(result, "Summary line");
+});
+
+// --- findFirstMatchingString ---
+
+Deno.test("findFirstMatchingString finds matching type", () => {
+  const types = ["/topic", "/talk", "/lab"];
+  assertEquals(findFirstMatchingString(types, "/root/talk-01", "/root"), "talk");
+});
+
+Deno.test("findFirstMatchingString returns unknown for no match", () => {
+  const types = ["/topic", "/talk"];
+  assertEquals(findFirstMatchingString(types, "/root/something", "/root"), "unknown");
+});
+
+Deno.test("findFirstMatchingString returns unknown for nested topic", () => {
+  const types = ["/topic", "/talk"];
+  assertEquals(findFirstMatchingString(types, "/root/topic/sub/path", "/root"), "unknown");
+});
+
+// --- findLastMatchingString ---
+
+Deno.test("findLastMatchingString finds last matching segment", () => {
+  const types = ["/topic", "/talk", "/lab"];
+  assertEquals(findLastMatchingString(types, "/root/topic-01/lab-01", "/root"), "lab");
+});
+
+Deno.test("findLastMatchingString returns unknown for no match", () => {
+  const types = ["/topic", "/talk"];
+  assertEquals(findLastMatchingString(types, "/root/something/other", "/root"), "unknown");
+});

--- a/cli/tutors-gen-lib/test/lr-utils.test.ts
+++ b/cli/tutors-gen-lib/test/lr-utils.test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from "jsr:@std/assert";
+import { getRoute, getId, removeLeadingHashes } from "../src/utils/lr-utils.ts";
+import type { LearningResource } from "../src/types/types.ts";
+
+function makeLr(overrides: Partial<LearningResource> = {}): LearningResource {
+  return {
+    type: "note",
+    id: "test-note",
+    route: "/root/topic-01/note-01",
+    courseRoot: "/root",
+    files: [],
+    lrs: [],
+    ...overrides,
+  } as LearningResource;
+}
+
+// --- getRoute ---
+
+Deno.test("getRoute builds route with COURSEURL placeholder", () => {
+  const lr = makeLr({ type: "note", route: "/root/topic-01/note-01", courseRoot: "/root" });
+  const result = getRoute(lr);
+  assertEquals(result, "/note/{{COURSEURL}}/topic-01/note-01");
+});
+
+Deno.test("getRoute strips courseRoot from path", () => {
+  const lr = makeLr({ type: "lab", route: "/my-course/topic-01/lab-01", courseRoot: "/my-course" });
+  const result = getRoute(lr);
+  assertEquals(result.includes("/my-course"), false);
+  assertEquals(result.startsWith("/lab/{{COURSEURL}}"), true);
+});
+
+// --- getId ---
+
+Deno.test("getId returns basename of route", () => {
+  const lr = makeLr({ route: "/root/topic-01/note-01" });
+  assertEquals(getId(lr), "note-01");
+});
+
+Deno.test("getId handles route with single segment", () => {
+  const lr = makeLr({ route: "/course" });
+  assertEquals(getId(lr), "course");
+});
+
+// --- removeLeadingHashes ---
+
+Deno.test("removeLeadingHashes with no hashes returns original", () => {
+  assertEquals(removeLeadingHashes("hello"), "hello");
+});
+
+Deno.test("removeLeadingHashes removes single hash", () => {
+  assertEquals(removeLeadingHashes("#title"), "title");
+});
+
+Deno.test("removeLeadingHashes removes multiple hashes", () => {
+  assertEquals(removeLeadingHashes("###heading"), "heading");
+});

--- a/cli/tutors-model-lib/test/course-utils.test.ts
+++ b/cli/tutors-model-lib/test/course-utils.test.ts
@@ -1,0 +1,187 @@
+import { assertEquals, assertExists } from "jsr:@std/assert";
+import { createCompanions, createWalls, loadPropertyFlags } from "../src/utils/course-utils.ts";
+import type { Course, Lo, Composite } from "../src/types/learning-objects.ts";
+import type { Properties } from "../src/types/type-utils.ts";
+
+function makeLo(overrides: Partial<Lo> = {}): Lo {
+  return {
+    type: "note",
+    id: "test",
+    title: "Test",
+    summary: "",
+    contentMd: "",
+    frontMatter: {},
+    route: "/test",
+    authLevel: 0,
+    img: "",
+    imgFile: "",
+    video: "",
+    videoids: { videoid: "", videoIds: [] },
+    hide: false,
+    ...overrides,
+  } as Lo;
+}
+
+function makeCourse(overrides: Partial<Course> = {}): Course {
+  return {
+    ...makeLo({ type: "course" }),
+    courseId: "test-course",
+    courseUrl: "https://example.com",
+    topicIndex: new Map(),
+    loIndex: new Map(),
+    properties: {} as Properties,
+    authLevel: 0,
+    isPortfolio: false,
+    isPrivate: false,
+    llm: 0,
+    pdfOrientation: "landscape",
+    areVideosHidden: false,
+    areLabStepsAutoNumbered: false,
+    hasEnrollment: false,
+    hasCalendar: false,
+    defaultPdfReader: "adobe",
+    footer: "",
+    ignorePin: "",
+    companions: { show: false, bar: [] },
+    wallBar: { show: false, bar: [] },
+    los: [],
+    toc: [],
+    panels: { panelVideos: [], panelTalks: [], panelNotes: [], panelPodcasts: [] },
+    units: { units: [], sides: [], standardLos: [] },
+    ...overrides,
+  } as Course;
+}
+
+// --- createCompanions ---
+
+Deno.test("createCompanions creates empty bar when no properties", () => {
+  const course = makeCourse({ properties: {} as Properties });
+  createCompanions(course);
+  assertEquals(course.companions.bar.length, 0);
+  assertEquals(course.companions.show, false);
+});
+
+Deno.test("createCompanions adds slack companion from properties", () => {
+  const props = { slack: "https://slack.example.com" } as unknown as Properties;
+  const course = makeCourse({ properties: props });
+  createCompanions(course);
+  assertEquals(course.companions.bar.length, 1);
+  assertEquals(course.companions.bar[0].type, "slack");
+  assertEquals(course.companions.bar[0].link, "https://slack.example.com");
+  assertEquals(course.companions.bar[0].target, "_blank");
+  assertEquals(course.companions.show, true);
+});
+
+Deno.test("createCompanions adds multiple companions", () => {
+  const props = {
+    slack: "https://slack.example.com",
+    zoom: "https://zoom.example.com",
+    youtube: "https://youtube.com/channel",
+  } as unknown as Properties;
+  const course = makeCourse({ properties: props });
+  createCompanions(course);
+  assertEquals(course.companions.bar.length, 3);
+  const types = course.companions.bar.map((c) => c.type);
+  assertEquals(types.includes("slack"), true);
+  assertEquals(types.includes("zoom"), true);
+  assertEquals(types.includes("youtube"), true);
+});
+
+Deno.test("createCompanions adds teams companion", () => {
+  const props = { teams: "https://teams.microsoft.com/join" } as unknown as Properties;
+  const course = makeCourse({ properties: props });
+  createCompanions(course);
+  assertEquals(course.companions.bar.length, 1);
+  assertEquals(course.companions.bar[0].type, "teams");
+});
+
+// --- createWalls ---
+
+Deno.test("createWalls creates empty walls for course with no Los", () => {
+  const course = makeCourse({ los: [] });
+  createWalls(course);
+  assertExists(course.walls);
+  assertEquals(course.walls!.length, 0);
+  assertEquals(course.wallBar.bar.length, 0);
+});
+
+Deno.test("createWalls creates walls for course with typed Los", () => {
+  const los = [
+    makeLo({ id: "t1", type: "talk", hide: false }),
+    makeLo({ id: "t2", type: "talk", hide: false }),
+    makeLo({ id: "l1", type: "lab", hide: false }),
+  ];
+  const course = makeCourse({ los });
+  createWalls(course);
+  assertExists(course.walls);
+  assertEquals(course.walls!.length > 0, true);
+  assertEquals(course.wallBar.bar.length > 0, true);
+});
+
+Deno.test("createWalls excludes hidden Los from wallMap", () => {
+  const los = [makeLo({ id: "hidden", type: "talk", hide: true })];
+  const course = makeCourse({ los });
+  createWalls(course);
+  assertEquals(course.wallMap?.has("talk"), false);
+});
+
+// --- loadPropertyFlags ---
+
+Deno.test("loadPropertyFlags sets default pdfOrientation to landscape", () => {
+  const course = makeCourse({ properties: {} as Properties, los: [] });
+  loadPropertyFlags(course);
+  assertEquals(course.pdfOrientation, "landscape");
+});
+
+Deno.test("loadPropertyFlags sets default pdfReader to adobe", () => {
+  const course = makeCourse({ properties: {} as Properties, los: [] });
+  loadPropertyFlags(course);
+  assertEquals(course.defaultPdfReader, "adobe");
+});
+
+Deno.test("loadPropertyFlags reads pdfOrientation from properties", () => {
+  const props = { pdfOrientation: "portrait" } as unknown as Properties;
+  const course = makeCourse({ properties: props, los: [] });
+  loadPropertyFlags(course);
+  assertEquals(course.pdfOrientation, "portrait");
+});
+
+Deno.test("loadPropertyFlags reads defaultPdfReader from properties", () => {
+  const props = { defaultPdfReader: "google" } as unknown as Properties;
+  const course = makeCourse({ properties: props, los: [] });
+  loadPropertyFlags(course);
+  assertEquals(course.defaultPdfReader, "google");
+});
+
+Deno.test("loadPropertyFlags sets isPortfolio from properties", () => {
+  const props = { portfolio: true } as unknown as Properties;
+  const course = makeCourse({ properties: props, los: [] });
+  loadPropertyFlags(course);
+  assertEquals(course.isPortfolio, true);
+});
+
+Deno.test("loadPropertyFlags sets isPrivate from properties", () => {
+  const props = { private: 1 } as unknown as Properties;
+  const course = makeCourse({ properties: props, los: [] });
+  loadPropertyFlags(course);
+  assertEquals(course.isPrivate, true);
+});
+
+Deno.test("loadPropertyFlags sets authLevel from properties", () => {
+  const props = { auth: 2 } as unknown as Properties;
+  const course = makeCourse({ properties: props, los: [] });
+  loadPropertyFlags(course);
+  assertEquals(course.authLevel, 2);
+});
+
+Deno.test("loadPropertyFlags sets hasEnrollment when enrollment exists", () => {
+  const course = makeCourse({ properties: {} as Properties, los: [], enrollment: { students: [] } as any });
+  loadPropertyFlags(course);
+  assertEquals(course.hasEnrollment, true);
+});
+
+Deno.test("loadPropertyFlags sets hasCalendar when calendar exists", () => {
+  const course = makeCourse({ properties: {} as Properties, los: [], calendar: { title: "test" } as any });
+  loadPropertyFlags(course);
+  assertEquals(course.hasCalendar, true);
+});

--- a/cli/tutors-model-lib/test/lo-utils.test.ts
+++ b/cli/tutors-model-lib/test/lo-utils.test.ts
@@ -1,0 +1,324 @@
+import { assertEquals, assertExists } from "jsr:@std/assert";
+import {
+  flattenLos,
+  filterByType,
+  removeLeadingHashes,
+  sortLos,
+  injectCourseUrl,
+  removeUnknownLos,
+  allVideoLos,
+  getPanels,
+  getUnits,
+  crumbs,
+  loadIcon,
+  fixRoutePaths,
+} from "../src/utils/lo-utils.ts";
+import type { Lo, Composite } from "../src/types/learning-objects.ts";
+
+function makeLo(overrides: Partial<Lo> = {}): Lo {
+  return {
+    type: "note",
+    id: "test",
+    title: "Test",
+    summary: "",
+    contentMd: "",
+    frontMatter: {},
+    route: "/test",
+    authLevel: 0,
+    img: "",
+    imgFile: "",
+    video: "",
+    videoids: { videoid: "", videoIds: [] },
+    hide: false,
+    ...overrides,
+  } as Lo;
+}
+
+function makeCompositeLo(type: string, los: Lo[]): Composite {
+  return {
+    ...makeLo({ type }),
+    los,
+    toc: [],
+    panels: { panelVideos: [], panelTalks: [], panelNotes: [], panelPodcasts: [] },
+    units: { units: [], sides: [], standardLos: [] },
+  } as unknown as Composite;
+}
+
+// --- flattenLos ---
+
+Deno.test("flattenLos returns empty for empty array", () => {
+  assertEquals(flattenLos([]), []);
+});
+
+Deno.test("flattenLos returns same array for flat list", () => {
+  const los = [makeLo({ id: "a" }), makeLo({ id: "b" })];
+  const result = flattenLos(los);
+  assertEquals(result.length, 2);
+  assertEquals(result[0].id, "a");
+  assertEquals(result[1].id, "b");
+});
+
+Deno.test("flattenLos flattens nested composite Los", () => {
+  const child1 = makeLo({ id: "child1", type: "note" });
+  const child2 = makeLo({ id: "child2", type: "lab" });
+  const parent = makeCompositeLo("topic", [child1, child2]);
+  parent.id = "parent";
+
+  const result = flattenLos([parent]);
+  assertEquals(result.length, 3);
+  assertEquals(result[0].id, "parent");
+  assertEquals(result[1].id, "child1");
+  assertEquals(result[2].id, "child2");
+});
+
+Deno.test("flattenLos handles deeply nested structures", () => {
+  const leaf = makeLo({ id: "leaf", type: "note" });
+  const inner = makeCompositeLo("unit", [leaf]);
+  inner.id = "inner";
+  const outer = makeCompositeLo("topic", [inner as unknown as Lo]);
+  outer.id = "outer";
+
+  const result = flattenLos([outer]);
+  assertEquals(result.length, 3);
+  assertEquals(result[0].id, "outer");
+  assertEquals(result[1].id, "inner");
+  assertEquals(result[2].id, "leaf");
+});
+
+// --- filterByType ---
+
+Deno.test("filterByType returns matching Los", () => {
+  const los = [
+    makeLo({ id: "a", type: "note" }),
+    makeLo({ id: "b", type: "lab" }),
+    makeLo({ id: "c", type: "note" }),
+  ];
+  const result = filterByType(los, "note");
+  assertEquals(result.length, 2);
+  assertEquals(result[0].id, "a");
+  assertEquals(result[1].id, "c");
+});
+
+Deno.test("filterByType returns empty for no matches", () => {
+  const los = [makeLo({ type: "note" }), makeLo({ type: "lab" })];
+  assertEquals(filterByType(los, "talk").length, 0);
+});
+
+Deno.test("filterByType finds nested Los by type", () => {
+  const nested = makeLo({ id: "nested-lab", type: "lab" });
+  const parent = makeCompositeLo("topic", [nested]);
+  parent.id = "topic";
+
+  const result = filterByType([parent], "lab");
+  assertEquals(result.length, 1);
+  assertEquals(result[0].id, "nested-lab");
+});
+
+// --- removeLeadingHashes ---
+
+Deno.test("removeLeadingHashes with no hashes returns original", () => {
+  assertEquals(removeLeadingHashes("hello"), "hello");
+});
+
+Deno.test("removeLeadingHashes removes single hash prefix", () => {
+  assertEquals(removeLeadingHashes("#title"), "title");
+});
+
+Deno.test("removeLeadingHashes removes multiple hash prefixes", () => {
+  assertEquals(removeLeadingHashes("###title"), "title");
+});
+
+Deno.test("removeLeadingHashes handles hash in middle", () => {
+  assertEquals(removeLeadingHashes("foo#bar"), "bar");
+});
+
+// --- sortLos ---
+
+Deno.test("sortLos places ordered items before unordered", () => {
+  const los = [
+    makeLo({ id: "unordered", frontMatter: {} }),
+    makeLo({ id: "ordered2", frontMatter: { order: 2 } as any }),
+    makeLo({ id: "ordered1", frontMatter: { order: 1 } as any }),
+  ];
+  const result = sortLos(los);
+  assertEquals(result[0].id, "ordered1");
+  assertEquals(result[1].id, "ordered2");
+  assertEquals(result[2].id, "unordered");
+});
+
+Deno.test("sortLos returns unordered items in original order", () => {
+  const los = [
+    makeLo({ id: "a" }),
+    makeLo({ id: "b" }),
+    makeLo({ id: "c" }),
+  ];
+  const result = sortLos(los);
+  assertEquals(result[0].id, "a");
+  assertEquals(result[1].id, "b");
+  assertEquals(result[2].id, "c");
+});
+
+// --- removeUnknownLos ---
+
+Deno.test("removeUnknownLos removes unknown type", () => {
+  const los = [
+    makeLo({ id: "a", type: "note" }),
+    makeLo({ id: "b", type: "unknown" }),
+    makeLo({ id: "c", type: "lab" }),
+  ];
+  removeUnknownLos(los);
+  assertEquals(los.length, 2);
+  assertEquals(los[0].id, "a");
+  assertEquals(los[1].id, "c");
+});
+
+Deno.test("removeUnknownLos leaves array unchanged if no unknowns", () => {
+  const los = [makeLo({ type: "note" }), makeLo({ type: "lab" })];
+  removeUnknownLos(los);
+  assertEquals(los.length, 2);
+});
+
+// --- allVideoLos ---
+
+Deno.test("allVideoLos returns only Los with video", () => {
+  const los = [
+    makeLo({ id: "a", video: "https://youtube.com/123" }),
+    makeLo({ id: "b", video: "" }),
+    makeLo({ id: "c", video: "https://youtube.com/456" }),
+  ];
+  const result = allVideoLos(los);
+  assertEquals(result.length, 2);
+  assertEquals(result[0].id, "a");
+  assertEquals(result[1].id, "c");
+});
+
+Deno.test("allVideoLos returns empty for no videos", () => {
+  const los = [makeLo({ video: "" }), makeLo({ video: "" })];
+  assertEquals(allVideoLos(los).length, 0);
+});
+
+// --- getPanels ---
+
+Deno.test("getPanels partitions Los into panel types", () => {
+  const los = [
+    makeLo({ id: "pv", type: "panelvideo" }),
+    makeLo({ id: "pt", type: "paneltalk" }),
+    makeLo({ id: "pn", type: "panelnote" }),
+    makeLo({ id: "pp", type: "podcast" }),
+    makeLo({ id: "other", type: "note" }),
+  ];
+  const panels = getPanels(los);
+  assertEquals(panels.panelVideos.length, 1);
+  assertEquals(panels.panelTalks.length, 1);
+  assertEquals(panels.panelNotes.length, 1);
+  assertEquals(panels.panelPodcasts.length, 1);
+});
+
+Deno.test("getPanels returns empty arrays when no panel types", () => {
+  const los = [makeLo({ type: "note" }), makeLo({ type: "lab" })];
+  const panels = getPanels(los);
+  assertEquals(panels.panelVideos.length, 0);
+  assertEquals(panels.panelTalks.length, 0);
+  assertEquals(panels.panelNotes.length, 0);
+  assertEquals(panels.panelPodcasts.length, 0);
+});
+
+// --- getUnits ---
+
+Deno.test("getUnits separates units, sides, and standard Los", () => {
+  const los = [
+    makeLo({ id: "u", type: "unit" }),
+    makeLo({ id: "s", type: "side" }),
+    makeLo({ id: "n", type: "note" }),
+    makeLo({ id: "l", type: "lab" }),
+  ];
+  const units = getUnits(los);
+  assertEquals(units.units.length, 1);
+  assertEquals(units.sides.length, 1);
+  assertEquals(units.standardLos.length, 2);
+});
+
+Deno.test("getUnits excludes panel types from standardLos", () => {
+  const los = [
+    makeLo({ type: "panelvideo" }),
+    makeLo({ type: "paneltalk" }),
+    makeLo({ type: "panelnote" }),
+    makeLo({ type: "podcast" }),
+    makeLo({ id: "note1", type: "note" }),
+  ];
+  const units = getUnits(los);
+  assertEquals(units.standardLos.length, 1);
+  assertEquals(units.standardLos[0].id, "note1");
+});
+
+// --- loadIcon ---
+
+Deno.test("loadIcon returns undefined when no frontMatter icon", () => {
+  const lo = makeLo({ frontMatter: {} });
+  assertEquals(loadIcon(lo), undefined);
+});
+
+Deno.test("loadIcon returns IconType when frontMatter has icon", () => {
+  const lo = makeLo({ frontMatter: { icon: { type: "mdi-book", color: "red" } } as any });
+  const icon = loadIcon(lo);
+  assertExists(icon);
+  assertEquals(icon!.type, "mdi-book");
+  assertEquals(icon!.color, "red");
+});
+
+// --- crumbs ---
+
+Deno.test("crumbs builds breadcrumb chain from parent links", () => {
+  const grandparent = makeLo({ id: "course", title: "Course", route: "/course" });
+  const parent = makeLo({ id: "topic", title: "Topic", route: "/topic", parentLo: grandparent });
+  const child = makeLo({ id: "lab", title: "Lab", route: "/lab", parentLo: parent });
+
+  const result: Lo[] = [];
+  crumbs(child, result);
+  assertEquals(result.length, 3);
+  assertEquals(result[0].id, "course");
+  assertEquals(result[1].id, "topic");
+  assertEquals(result[2].id, "lab");
+});
+
+Deno.test("crumbs handles undefined lo", () => {
+  const result: Lo[] = [];
+  crumbs(undefined, result);
+  assertEquals(result.length, 0);
+});
+
+Deno.test("crumbs strips trailing slash from route", () => {
+  const lo = makeLo({ route: "/test/" });
+  const result: Lo[] = [];
+  crumbs(lo, result);
+  assertEquals(result[0].route, "/test");
+});
+
+// --- fixRoutePaths ---
+
+Deno.test("fixRoutePaths replaces leading # with / in route", () => {
+  const lo = makeLo({ route: "#lab/test" });
+  fixRoutePaths(lo);
+  assertEquals(lo.route, "/lab/test");
+});
+
+Deno.test("fixRoutePaths replaces leading # with / in video", () => {
+  const lo = makeLo({ route: "/ok", video: "#video/test" });
+  fixRoutePaths(lo);
+  assertEquals(lo.video, "/video/test");
+});
+
+// --- injectCourseUrl ---
+
+Deno.test("injectCourseUrl replaces {{COURSEURL}} in route", () => {
+  const lo = makeLo({ id: "n", type: "note", route: "/note/{{COURSEURL}}/topic-01" });
+  injectCourseUrl([lo], "course-id", "https://example.com/course");
+  assertEquals(lo.route.includes("{{COURSEURL}}"), false);
+  assertEquals(lo.route.includes("course-id"), true);
+});
+
+Deno.test("injectCourseUrl replaces {{COURSEURL}} in img", () => {
+  const lo = makeLo({ img: "https://{{COURSEURL}}/img/main.png" });
+  injectCourseUrl([lo], "id", "https://example.com");
+  assertEquals(lo.img, "https://https://example.com/img/main.png");
+});

--- a/cli/tutors-model-lib/test/search.test.ts
+++ b/cli/tutors-model-lib/test/search.test.ts
@@ -1,0 +1,109 @@
+import { assertEquals } from "jsr:@std/assert";
+import { searchHits, extractPath, isValid } from "../src/services/search.ts";
+import type { Lo } from "../src/types/learning-objects.ts";
+
+function makeLo(overrides: Partial<Lo> = {}): Lo {
+  return {
+    type: "note",
+    id: "test",
+    title: "Test",
+    summary: "",
+    contentMd: "",
+    frontMatter: {},
+    route: "/test",
+    authLevel: 0,
+    img: "",
+    imgFile: "",
+    video: "",
+    videoids: { videoid: "", videoIds: [] },
+    hide: false,
+    ...overrides,
+  } as Lo;
+}
+
+// --- isValid ---
+
+Deno.test("isValid returns true for non-empty string", () => {
+  assertEquals(isValid("hello"), true);
+});
+
+Deno.test("isValid returns false for whitespace-only string", () => {
+  assertEquals(isValid("   "), false);
+});
+
+Deno.test("isValid returns false for empty string", () => {
+  assertEquals(isValid(""), false);
+});
+
+Deno.test("isValid returns true for string with mixed content", () => {
+  assertEquals(isValid("  hello  "), true);
+});
+
+// --- extractPath ---
+
+Deno.test("extractPath inserts / after #", () => {
+  const input = '<a href="#lab/topic-01/lab-01">Lab 01</a>';
+  const result = extractPath(input);
+  assertEquals(result.startsWith("#/"), true);
+});
+
+Deno.test("extractPath extracts path from href", () => {
+  const input = '<a href="#lab/topic-01/lab-01">Lab 01</a>';
+  const result = extractPath(input);
+  assertEquals(result, "#/lab/topic-01/lab-01");
+});
+
+// --- searchHits ---
+
+Deno.test("searchHits returns empty for no matches", () => {
+  const los = [makeLo({ contentMd: "hello world\nfoo bar" })];
+  const results = searchHits(los, "zzzzz");
+  assertEquals(results.length, 0);
+});
+
+Deno.test("searchHits finds term in contentMd", () => {
+  const los = [makeLo({ contentMd: "hello world\nfoo bar\nbaz qux", route: "/test", parentLo: makeLo({ title: "Parent" }) })];
+  const results = searchHits(los, "foo");
+  assertEquals(results.length > 0, true);
+  assertEquals(results[0].contentMd.includes("foo"), true);
+});
+
+Deno.test("searchHits finds multiple occurrences", () => {
+  const los = [makeLo({
+    contentMd: "apple banana\napple cherry\norange apple",
+    route: "/test",
+    parentLo: makeLo({ title: "Parent" }),
+  })];
+  const results = searchHits(los, "apple");
+  assertEquals(results.length, 3);
+});
+
+Deno.test("searchHits respects max 100 hits limit", () => {
+  const lines = Array.from({ length: 150 }, (_, i) => `match${i} target`).join("\n");
+  const los = [makeLo({ contentMd: lines, route: "/test", parentLo: makeLo({ title: "P" }) })];
+  const results = searchHits(los, "target");
+  assertEquals(results.length <= 100, true);
+});
+
+Deno.test("searchHits skips Los without contentMd", () => {
+  const los = [makeLo({ contentMd: "" })];
+  const results = searchHits(los, "anything");
+  assertEquals(results.length, 0);
+});
+
+Deno.test("searchHits detects fenced code blocks", () => {
+  const content = "some text\n```javascript\nconst x = searchterm;\n```\nmore text";
+  const los = [makeLo({ contentMd: content, route: "/test", parentLo: makeLo({ title: "P" }) })];
+  const results = searchHits(los, "searchterm");
+  assertEquals(results.length > 0, true);
+  assertEquals(results[0].fenced, true);
+  assertEquals(results[0].language, "javascript");
+});
+
+Deno.test("searchHits marks unfenced content", () => {
+  const content = "some plain text with keyword here\nno fences at all";
+  const los = [makeLo({ contentMd: content, route: "/test", parentLo: makeLo({ title: "P" }) })];
+  const results = searchHits(los, "keyword");
+  assertEquals(results.length > 0, true);
+  assertEquals(results[0].fenced, false);
+});

--- a/cli/tutors-model-lib/test/type-utils.test.ts
+++ b/cli/tutors-model-lib/test/type-utils.test.ts
@@ -1,0 +1,74 @@
+import { assertEquals } from "jsr:@std/assert";
+import {
+  isCompositeLo,
+  simpleTypes,
+  loCompositeTypes,
+  loTypes,
+  preOrder,
+} from "../src/types/type-utils.ts";
+import type { Lo } from "../src/types/learning-objects.ts";
+
+function makeLo(type: string): Lo {
+  return {
+    type,
+    id: "test",
+    title: "Test",
+    summary: "",
+    contentMd: "",
+    frontMatter: {},
+    route: "/test",
+    authLevel: 0,
+    img: "",
+    imgFile: "",
+    video: "",
+    videoids: { videoid: "", videoIds: [] },
+    hide: false,
+  } as Lo;
+}
+
+Deno.test("isCompositeLo returns true for composite types", () => {
+  for (const type of ["unit", "side", "topic", "course"]) {
+    assertEquals(isCompositeLo(makeLo(type)), true, `${type} should be composite`);
+  }
+});
+
+Deno.test("isCompositeLo returns false for simple types", () => {
+  for (const type of ["lab", "talk", "note", "web", "archive", "github", "panelnote", "paneltalk", "panelvideo", "podcast", "tutorial", "book", "notebook"]) {
+    assertEquals(isCompositeLo(makeLo(type)), false, `${type} should not be composite`);
+  }
+});
+
+Deno.test("simpleTypes contains expected types", () => {
+  const expected = ["note", "archive", "web", "github", "panelnote", "paneltalk", "panelvideo", "podcast", "talk", "book", "lab", "tutorial", "notebook"];
+  assertEquals(simpleTypes.length, expected.length);
+  for (const t of expected) {
+    assertEquals(simpleTypes.includes(t), true, `simpleTypes should include ${t}`);
+  }
+});
+
+Deno.test("loCompositeTypes contains unit, side, topic, course", () => {
+  assertEquals(loCompositeTypes, ["unit", "side", "topic", "course"]);
+});
+
+Deno.test("loTypes is simpleTypes + loCompositeTypes", () => {
+  assertEquals(loTypes.length, simpleTypes.length + loCompositeTypes.length);
+  for (const t of simpleTypes) {
+    assertEquals(loTypes.includes(t), true, `loTypes should include simple type ${t}`);
+  }
+  for (const t of loCompositeTypes) {
+    assertEquals(loTypes.includes(t), true, `loTypes should include composite type ${t}`);
+  }
+});
+
+Deno.test("preOrder map covers all loTypes", () => {
+  for (const t of loTypes) {
+    assertEquals(preOrder.has(t), true, `preOrder should have entry for ${t}`);
+  }
+});
+
+Deno.test("preOrder values are sequential from 0", () => {
+  const values = Array.from(preOrder.values()).sort((a, b) => a - b);
+  for (let i = 0; i < values.length; i++) {
+    assertEquals(values[i], i, `preOrder value at index ${i} should be ${i}`);
+  }
+});


### PR DESCRIPTION
## Summary
- **91 new unit tests** covering previously untested pure utility functions across `tutors-model-lib` and `tutors-gen-lib`
- **GitHub Actions CI workflow** that runs Deno tests on push to `development` and on pull requests
- All tests use Deno.test + @std/assert, matching the existing test conventions

## Test Coverage

### cli/tutors-model-lib (66 tests — previously had zero tests)
- `lo-utils.test.ts` (30 tests): flattenLos, filterByType, removeLeadingHashes, sortLos, injectCourseUrl, removeUnknownLos, allVideoLos, getPanels, getUnits, crumbs, loadIcon, fixRoutePaths
- `type-utils.test.ts` (7 tests): isCompositeLo, simpleTypes, loCompositeTypes, loTypes, preOrder
- `course-utils.test.ts` (16 tests): createCompanions, createWalls, loadPropertyFlags
- `search.test.ts` (13 tests): searchHits, extractPath, isValid

### cli/tutors-gen-lib (25 tests)
- `file-utils.test.ts` (18 tests): removeFirstLine, getFileName, getFileType, getHeaderFromBody, withoutHeaderFromBody, findFirstMatchingString, findLastMatchingString
- `lr-utils.test.ts` (7 tests): getRoute, getId, removeLeadingHashes

### CI Workflow
- `.github/workflows/test.yml`: Runs on push to `development` and PRs, uses Deno v2.x, generates coverage report

## Test plan
- [x] All 91 tests pass locally with `deno test --no-check -A`
- [ ] CI workflow runs successfully on this PR
- [ ] Verify no regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)